### PR TITLE
Add support to multiple user shares in ExpenseByShare

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -88,18 +88,29 @@ func expensesExamples(client splitwise.Client) {
 		fmt.Printf("%+v\n", exp)
 	}
 
-	expenses, err := client.CreateExpenseByShare(context.Background(), splitwise.ExpenseByShare{
-		Expense: splitwise.Expense{
+	userShares := []splitwise.UserShare{
+		{
+			UserID:    27163610,
+			PaidShare: "15000.00",
+			OwedShare: "7500.00",
+		},
+		{
+			UserID:    58839462,
+			PaidShare: "0.00",
+			OwedShare: "7500.00",
+		},
+	}
+
+	expenses, err := client.CreateExpenseByShare(
+		context.Background(),
+		splitwise.Expense{
 			Cost:         "15000.00",
 			Description:  "کافه امروز عصر",
 			CurrencyCode: "IRR",
 			GroupId:      0,
 		},
-		PaidUserID: 27163610,
-		OwedUserID: 58839462,
-		PaidShare:  "15000.00",
-		OwedShare:  "15000.00",
-	})
+		userShares,
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/expenses_test.go
+++ b/expenses_test.go
@@ -174,22 +174,53 @@ func TestClient_CreateExpenseSplitEqually(t *testing.T) {
 
 func TestClient_CreateExpenseByShare(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
+		type ExpenseByShare struct {
+			Expense
+			UserID0    uint64 `json:"users__0__user_id"`
+			PaidShare0 string `json:"users__0__paid_share"`
+			OwedShare0 string `json:"users__0__owed_share"`
+			UserID1    uint64 `json:"users__1__user_id"`
+			PaidShare1 string `json:"users__1__paid_share"`
+			OwedShare1 string `json:"users__1__owed_share"`
+		}
+
+		expense := Expense{
+			Cost:           "25",
+			Description:    "Grocery run",
+			Details:        "string",
+			Date:           "2012-05-02T13:00:00Z",
+			RepeatInterval: "never",
+			CurrencyCode:   "USD",
+			CategoryId:     15,
+			GroupId:        0,
+		}
+
+		user1 := UserShare{
+			UserID:    54123,
+			PaidShare: "25",
+			OwedShare: "15",
+		}
+
+		user2 := UserShare{
+			UserID:    34262,
+			PaidShare: "0",
+			OwedShare: "10",
+		}
+
+		userShares := []UserShare{
+			user1,
+			user2,
+		}
+
 		expectedReqBody := []ExpenseByShare{
 			{
-				Expense: Expense{
-					Cost:           "25",
-					Description:    "Grocery run",
-					Details:        "string",
-					Date:           "2012-05-02T13:00:00Z",
-					RepeatInterval: "never",
-					CurrencyCode:   "USD",
-					CategoryId:     15,
-					GroupId:        0,
-				},
-				PaidUserID: 54123,
-				OwedUserID: 34262,
-				PaidShare:  "25",
-				OwedShare:  "25",
+				Expense:    expense,
+				UserID0:    user1.UserID,
+				PaidShare0: user1.PaidShare,
+				OwedShare0: user1.OwedShare,
+				UserID1:    user2.UserID,
+				PaidShare1: user2.PaidShare,
+				OwedShare1: user2.OwedShare,
 			},
 		}
 		// Start a local HTTP server
@@ -330,7 +361,7 @@ func TestClient_CreateExpenseByShare(t *testing.T) {
 			client:       http.DefaultClient,
 		}
 
-		_, err := c.CreateExpenseByShare(context.Background(), expectedReqBody[0])
+		_, err := c.CreateExpenseByShare(context.Background(), expense, userShares)
 
 		if err != nil {
 			t.Fatal(err)

--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,114 @@
+package splitwise
+
+import (
+	"fmt"
+	"reflect"
+)
+
+func NewErrFailConversion(value interface{}) error {
+	return fmt.Errorf("can't convert value %v", value)
+}
+
+func buildStructValues(structFields []reflect.StructField, values []interface{}) (interface{}, error) {
+	typ := reflect.StructOf(structFields)
+
+	instance := reflect.New(typ).Elem()
+	for i := 0; i < instance.NumField(); i++ {
+		varType := instance.Type().Field(i).Type
+		switch varType.Kind() {
+		case reflect.Int:
+			v, ok := (values[i]).(int)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetInt(int64(v))
+		case reflect.Int32:
+			v, ok := (values[i]).(int32)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetInt(int64(v))
+		case reflect.Int64:
+			v, ok := (values[i]).(int64)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetInt(v)
+		case reflect.Uint:
+			v, ok := (values[i]).(uint)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetUint(uint64(v))
+		case reflect.Uint32:
+			v, ok := (values[i]).(uint32)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetUint(uint64(v))
+		case reflect.Uint64:
+			v, ok := (values[i]).(uint64)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetUint(v)
+		case reflect.Float32:
+			v, ok := (values[i]).(float32)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetFloat(float64(v))
+		case reflect.Float64:
+			v, ok := (values[i]).(float64)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetFloat(v)
+		case reflect.Bool:
+			v, ok := (values[i]).(bool)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetBool(v)
+		case reflect.String:
+			v, ok := (values[i]).(string)
+			if !ok {
+				return nil, NewErrFailConversion(values[i])
+			}
+			instance.Field(i).SetString(v)
+		default:
+			return nil, fmt.Errorf("unexpected type %s", varType.Kind())
+		}
+	}
+
+	return instance.Addr().Interface(), nil
+}
+
+func mergeStructFields(inputs ...interface{}) ([]reflect.StructField, []interface{}) {
+	var fields []reflect.StructField
+	var finalValues []interface{}
+
+	for _, input := range inputs {
+		values := reflect.Indirect(reflect.ValueOf(input))
+		types := values.Type()
+
+		for i := 0; i < values.NumField(); i++ {
+			val := values.Field(i)
+			typ := types.Field(i)
+			fields = append(fields, reflect.StructField{
+				Name: typ.Name,
+				Type: reflect.TypeOf(val.Interface()),
+				Tag:  reflect.StructTag(string(typ.Tag)),
+			})
+			finalValues = append(finalValues, val.Interface())
+		}
+	}
+
+	return fields, finalValues
+}
+
+func MergeStructs(inputs ...interface{}) (interface{}, error) {
+	fields, values := mergeStructFields(inputs...)
+
+	return buildStructValues(fields, values)
+}


### PR DESCRIPTION
When creating an expense by share Splitwise API expects a list of (userID, paid share, owed share) as in users__{index}__{property}*. So an example of the user shares expected by splitwise API is as following:
  "users__0__user_id": 27742729,
  "users__0__paid_share": "26.95",
  "users__0__owed_share": "17.96",
  "users__1__user_id": 59044772,
  "users__1__paid_share": "0.00",
  "users__1__owed_share": "8.99"
As in the current implementation, passing only one paid share for one user and one owed share for another user is not enough for Splitwise to create the expense.
Now clients pass the Expense and a list of UserShare. Internally, we handle the list of UserShares and add it to a dynamic struct that represents the ExpenseByShare that will be sent as the request body.